### PR TITLE
Changed interpolateNoteX to be a bit faster

### DIFF
--- a/src/core/PianoRenderer.ts
+++ b/src/core/PianoRenderer.ts
@@ -13,6 +13,8 @@ const outOfRangeNoteSize = 10;
 
 let whiteKeyWidth: number;
 let blackKeyWidth: number;
+let rangeBase = 0;
+let rangeOffset = 0;
 
 export function init() {
 	pianoCanvas = document.getElementById("pianoCanvas") as HTMLCanvasElement;
@@ -169,8 +171,6 @@ export function isWhiteKey(note: Audio.Note) {
 	);
 }
 
-let rangeBase = 0;
-let rangeOffset = 0;
 export function interpolateNoteX(note: Audio.Note) {
 	// Piano Key is the index of the key on the Piano, pretending there are no gap in the black keys
 	const pianoKey = calculateNoteX(note) - rangeBase;


### PR DESCRIPTION
It's about 15-20% faster than the old one.
The test was:
```
function DEBUG_RunTest(){
 let start = performance.now();
 for(let i = 0; i < 120; i+=0.000001){
  interpolateNoteX(i); //The Old One
 }
 let end = performace.now();
 let oldTime = end - start;
 start = performance.now();
 for(let i = 0; i < 120; i+=0.000001){
  newInterpolateNoteX(i); //The New One
 }
 end = performace.now();
 let newTime = end - start;
 console.log("New: " + newTime + " | Old: " + oldTime);
}
```

Under those (quite unrealistic imo) circumstances the new One is faster. In my oppinion the new implementation is not worth the performace gain since its quite unreadable now since math is not as overviewable than a lerp and a map.